### PR TITLE
Fix dedicated server filter

### DIFF
--- a/src/steam/filters/filters.go
+++ b/src/steam/filters/filters.go
@@ -36,7 +36,7 @@ var (
 
 	// --------------------- "Constant" filters ---------------------
 	// Dedicated servers
-	SfDedicated SrvFilter = []byte("\\type\\d")
+	SfDedicated SrvFilter = []byte("\\dedicated\\1")
 	// Servers using anti-cheat technology (VAC, but maybe others as well)
 	SfSecure SrvFilter = []byte("\\secure\\1")
 	// Servers running on a Linux platform


### PR DESCRIPTION
Instead of `\type\d`, it should be `\dedicated\1`. See also: https://developer.valvesoftware.com/wiki/Master_Server_Query_Protocol